### PR TITLE
Data Wrangling for Drug Use Visualizations

### DIFF
--- a/cms/druguse_definitions.ipynb
+++ b/cms/druguse_definitions.ipynb
@@ -1,0 +1,1558 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# What are the various drugs prescribed for?\n",
+    "\n",
+    "We need some kind of knowledge of which drug is prescribed for which condition. Thankfully, CMS seems to have this information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'../data/2010_PD_Profiles_PUF.csv'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import requests # to download the dataset\n",
+    "import zipfile # to extract from archive\n",
+    "import shutil # to write the dataset to file\n",
+    "import os # rename file to something more type-able\n",
+    "import numpy as np\n",
+    "\n",
+    "data_dir = '../data/'\n",
+    "url = \"https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/BSAPUFS/Downloads/2010_PD_Profiles_PUF.zip\"\n",
+    "response = requests.get(url, stream=True)\n",
+    "\n",
+    "with open(data_dir + 'drug_profiles_dataset.zip', 'wb') as ds_zipout:\n",
+    "    shutil.copyfileobj(response.raw, ds_zipout)\n",
+    "\n",
+    "zip = zipfile.ZipFile(data_dir + 'drug_profiles_dataset.zip', 'r')\n",
+    "ds_filename = zip.namelist()[0]\n",
+    "zip.extract(ds_filename, path=data_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's load the data and have a look at what's in it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"../data/2010_PD_Profiles_PUF.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's drop the columns we don't need right now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df.drop(\"BENE_SEX_IDENT_CD\", axis=1, inplace=True)\n",
+    "df.drop(\"BENE_AGE_CAT_CD\", axis=1, inplace=True)\n",
+    "df.drop(\"PDE_DRUG_TYPE_CD\", axis=1, inplace=True)\n",
+    "df.drop(\"PLAN_TYPE\", axis=1, inplace=True)\n",
+    "df.drop([\"COVERAGE_TYPE\", \"benefit_phase\",\"DRUG_BENEFIT_TYPE\",\n",
+    "         \"PRESCRIBER_TYPE\", \"GAP_COVERAGE\", \"TIER_ID\", \"MEAN_RXHCC_SCORE\",\n",
+    "         \"AVE_DAYS_SUPPLY\", \"AVE_TOT_DRUG_COST\", \"AVE_PTNT_PAY_AMT\",\n",
+    "         \"PDE_CNT\", \"BENE_CNT_CAT\"], axis=1, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RXNORM_RXCUI</th>\n",
+       "      <th>DRUG_MAJOR_CLASS</th>\n",
+       "      <th>DRUG_CLASS</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RXNORM_RXCUI DRUG_MAJOR_CLASS DRUG_CLASS\n",
+       "0             0                0          0\n",
+       "1             0                0          0\n",
+       "2             0                0          0\n",
+       "3             0                0          0\n",
+       "4             0                0          0"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1229"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(df[\"RXNORM_RXCUI\"].unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## RXNorm Identifiers\n",
+    "\n",
+    "I need the identifiers for the `RXNORM_RXCUI` column and the `DRUG_MAJOR_CLASS` column.\n",
+    "\n",
+    "The former comes from the NIH in the form of a downloadable data table:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data_dir = '../data/'\n",
+    "url = \"https://download.nlm.nih.gov/rxnorm/RxNorm_full_prescribe_01032017.zip\"\n",
+    "response = requests.get(url, stream=True)\n",
+    "\n",
+    "with open(data_dir + 'rxnorm_dataset.zip', 'wb') as ds_zipout:\n",
+    "    shutil.copyfileobj(response.raw, ds_zipout)\n",
+    "\n",
+    "os.makedirs(data_dir+\"rxnorm/\")\n",
+    "zip = zipfile.ZipFile(data_dir + 'rxnorm_dataset.zip', 'r')\n",
+    "\n",
+    "ds_filenames = zip.namelist()\n",
+    "\n",
+    "for d in ds_filenames:\n",
+    "    zip.extract(d, path=data_dir+\"rxnorm/\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Columns:\n",
+    "\n",
+    "* RXCUI\tRxNorm Unique identifier for concept (concept ID)\n",
+    "* LAT\tLanguage of Term\n",
+    "* TS\tTerm status (no value provided)\n",
+    "* LUI\tUnique identifier for term (no value provided)\n",
+    "* STT\tString type (no value provided)\n",
+    "* SUI\tUnique identifier for string (no value provided)\n",
+    "* ISPREF\tAtom status - preferred (Y) or not (N) for this string within this concept (no value provided)\n",
+    "* RXAUI\tUnique identifier for atom (RxNorm Atom ID)\n",
+    "* SAUI\tSource asserted atom identifier [optional]\n",
+    "* SCUI\tSource asserted concept identifier [optional]\n",
+    "* SDUI\tSource asserted descriptor identifier [optional]\n",
+    "* SAB\tSource abbreviation\n",
+    "* TTY\tTerm type in source\n",
+    "* CODE\t\"Most useful\" source asserted identifier (if the source vocabulary has more than one identifier), or a RxNorm-generated source entry identifier (if the source vocabulary has none.)\n",
+    "* STR\tString\n",
+    "* SRL\tSource Restriction Level (no value provided)\n",
+    "* SUPPRESS\tSuppressible flag. Values = N, O, Y, or E. N - not suppressible. O - Specific individual names (atoms) set as Obsolete because the name is no longer provided by the original source. Y - Suppressed by RxNorm editor. E - unquantified, non-prescribable drug with related quantified, prescribable drugs. NLM strongly recommends that users not alter editor-assigned suppressibility.\n",
+    "* CVF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "names = [\"RXCUI\", \"LAT\", \"TS\", \"LUI\", \"STT\", \"SUI\", \"ISPREF\", \"RXAUI\",\n",
+    "         \"SAUI\", \"SCUI\", \"SDUI\", \"SAB\", \"TTY\", \"CODE\", \"STR\", \"SRL\", \"SUPPRESS\", \"CVF\"]\n",
+    "\n",
+    "rxnorm = pd.read_csv(\"../data/rxnorm/rrf/RXNCONSO.RRF\", sep=\"|\", names=names, index_col=False,\n",
+    "                     usecols=[0,14])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RXCUI</th>\n",
+       "      <th>STR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>38</td>\n",
+       "      <td>Parlodel</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>44</td>\n",
+       "      <td>mesna</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>44</td>\n",
+       "      <td>MESNA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>44</td>\n",
+       "      <td>Mesna</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>73</td>\n",
+       "      <td>Docosahexaenoate</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RXCUI               STR\n",
+       "0     38          Parlodel\n",
+       "1     44             mesna\n",
+       "2     44             MESNA\n",
+       "3     44             Mesna\n",
+       "4     73  Docosahexaenoate"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rxnorm.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RXCUI</th>\n",
+       "      <th>STR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>30703</th>\n",
+       "      <td>228476</td>\n",
+       "      <td>GATIFLOXACIN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        RXCUI           STR\n",
+       "30703  228476  GATIFLOXACIN"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rxnorm[rxnorm[\"STR\"] == \"GATIFLOXACIN\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need alll the names to be lowercase:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "rxnorm[\"STR\"] = rxnorm[\"STR\"].str.lower()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are going load the generic brand names from the Part D table so we can match them to RXCUI identifiers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import feather\n",
+    "drugnames = feather.read_dataframe('../data/drugnames.feather')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drugname_brand</th>\n",
+       "      <th>drugname_generic</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10 WASH</td>\n",
+       "      <td>SULFACETAMIDE SODIUM</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1ST TIER UNIFINE PENTIPS</td>\n",
+       "      <td>PEN NEEDLE, DIABETIC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1ST TIER UNIFINE PENTIPS PLUS</td>\n",
+       "      <td>PEN NEEDLE, DIABETIC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>60PSE-400GFN-20DM</td>\n",
+       "      <td>GUAIFENESIN/DM/PSEUDOEPHEDRINE</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8-MOP</td>\n",
+       "      <td>METHOXSALEN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  drugname_brand                drugname_generic\n",
+       "0                        10 WASH            SULFACETAMIDE SODIUM\n",
+       "1       1ST TIER UNIFINE PENTIPS            PEN NEEDLE, DIABETIC\n",
+       "2  1ST TIER UNIFINE PENTIPS PLUS            PEN NEEDLE, DIABETIC\n",
+       "3              60PSE-400GFN-20DM  GUAIFENESIN/DM/PSEUDOEPHEDRINE\n",
+       "4                          8-MOP                     METHOXSALEN"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drugnames.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Messing with the Drug Names\n",
+    "\n",
+    "Some of the drug names have multiple generic names. We need to pull those apart into their own categories. Also, we're going to transform them all to lowercase letters. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "drugnames[\"drugname_generic\"] = drugnames[\"drugname_generic\"].str.lower()\n",
+    "drugnames[\"drugname_brand\"] = drugnames[\"drugname_brand\"].str.lower()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drugname_brand</th>\n",
+       "      <th>drugname_generic</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10 wash</td>\n",
+       "      <td>sulfacetamide sodium</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1st tier unifine pentips</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1st tier unifine pentips plus</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>60pse-400gfn-20dm</td>\n",
+       "      <td>guaifenesin/dm/pseudoephedrine</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8-mop</td>\n",
+       "      <td>methoxsalen</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  drugname_brand                drugname_generic\n",
+       "0                        10 wash            sulfacetamide sodium\n",
+       "1       1st tier unifine pentips            pen needle, diabetic\n",
+       "2  1st tier unifine pentips plus            pen needle, diabetic\n",
+       "3              60pse-400gfn-20dm  guaifenesin/dm/pseudoephedrine\n",
+       "4                          8-mop                     methoxsalen"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drugnames.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need a placeholder for the `RXCUI` values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "drugnames[\"RXCUI\"] = \"0.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can try to associate the drug names with their `RXCUI` codes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for idx in drugnames.index:\n",
+    "\n",
+    "    d = drugnames.loc[idx, \"drugname_generic\"]\n",
+    "    dsplit = d.split(\"/\")\n",
+    "\n",
+    "    rxcui = []\n",
+    "    for di in dsplit:\n",
+    "        displit = di.split(\" \")\n",
+    "        v = rxnorm[rxnorm[\"STR\"] == displit[0]]\n",
+    "\n",
+    "        if len(v) > 0:\n",
+    "            rxcui.extend(v[\"RXCUI\"].unique())\n",
+    "        else:\n",
+    "            continue\n",
+    "\n",
+    "    d = drugnames.loc[idx, \"drugname_brand\"]\n",
+    "    dsplit = d.split(\" \")\n",
+    "    \n",
+    "    for di in dsplit:\n",
+    "        displit = di.split(\" \")\n",
+    "        v = rxnorm[rxnorm[\"STR\"] == displit[0]]\n",
+    "\n",
+    "        if len(v) > 0:\n",
+    "            rxcui.extend(v[\"RXCUI\"].unique())\n",
+    "        else:\n",
+    "            continue\n",
+    "\n",
+    "    if len(rxcui) > 1:\n",
+    "        rxcui_str = \"|\".join(np.array(rxcui, dtype=str))\n",
+    "        \n",
+    "    elif len(rxcui) == 1:\n",
+    "        rxcui_str = str(rxcui[0])\n",
+    "    else:\n",
+    "        rxcui_str = 0.0\n",
+    "    \n",
+    "    drugnames.loc[idx, \"RXCUI\"] = rxcui_str\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How many am I missing?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "620"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drugnames[drugnames[\"RXCUI\"] == 0.0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What fraction is that of all drug names?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.1378390395731436"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drugnames[drugnames[\"RXCUI\"] == 0.0])/len(drugnames)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "14% isn't so bad as a first turn-out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drugname_brand</th>\n",
+       "      <th>drugname_generic</th>\n",
+       "      <th>RXCUI</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1st tier unifine pentips</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1st tier unifine pentips plus</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>accusure</td>\n",
+       "      <td>syring w-ndl,disp,insul,0.5 ml</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>accusure</td>\n",
+       "      <td>syringe and needle,insulin,1ml</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>acetaminoph-caff-dihydrocodein</td>\n",
+       "      <td>dhcodeine bt/acetaminophn/caff</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    drugname_brand                drugname_generic RXCUI\n",
+       "1         1st tier unifine pentips            pen needle, diabetic     0\n",
+       "2    1st tier unifine pentips plus            pen needle, diabetic     0\n",
+       "22                        accusure  syring w-ndl,disp,insul,0.5 ml     0\n",
+       "23                        accusure  syringe and needle,insulin,1ml     0\n",
+       "26  acetaminoph-caff-dihydrocodein  dhcodeine bt/acetaminophn/caff     0"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drugnames[drugnames[\"RXCUI\"] == 0.0].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This seems to include things like prenatal vitamins, devices (like needles and syringes) and abbreviated names I can't automatically include. \n",
+    "**I am going to ignore this for the moment, but we should fix this in the long run!**\n",
+    "\n",
+    "## Associating Drug Classes\n",
+    "\n",
+    "Drug classes come originally from the Veteran's Health Administration [National Drug File](http://www.pbm.va.gov/PBM/nationalformulary/NDF_January_2016.xlsx). It turns out, they're also listed in the PUF SAS manual. Go figure:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data_dir = '../data/'\n",
+    "url = \"https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/BSAPUFS/Downloads/2010_PD_Profiles_PUF_DUG.zip\"\n",
+    "response = requests.get(url, stream=True)\n",
+    "\n",
+    "with open(data_dir + 'drug_classes_dataset.zip', 'wb') as ds_zipout:\n",
+    "    shutil.copyfileobj(response.raw, ds_zipout)\n",
+    "\n",
+    "zip = zipfile.ZipFile(data_dir + 'drug_classes_dataset.zip', 'r')\n",
+    "ds_filenames = zip.namelist()\n",
+    "for f in ds_filenames:\n",
+    "    zip.extract(f, path=data_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "drug_major_class = pd.read_csv(data_dir+\"DRUG_MAJOR_CLASS_TABLE.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drug_major_class</th>\n",
+       "      <th>drug_major_class_desc</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AD000</td>\n",
+       "      <td>ANTIDOTES,DETERRENTS AND POISON CONTROL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AH000</td>\n",
+       "      <td>ANTIHISTAMINES</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AM000</td>\n",
+       "      <td>ANTIMICROBIALS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AN000</td>\n",
+       "      <td>ANTINEOPLASTICS</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  drug_major_class                    drug_major_class_desc\n",
+       "0                0                          UNKNOWN/MISSING\n",
+       "1            AD000  ANTIDOTES,DETERRENTS AND POISON CONTROL\n",
+       "2            AH000                           ANTIHISTAMINES\n",
+       "3            AM000                           ANTIMICROBIALS\n",
+       "4            AN000                          ANTINEOPLASTICS"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_major_class.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "drug_class = pd.read_csv(data_dir+\"DRUG_CLASS_TABLE.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drug_class</th>\n",
+       "      <th>drug_class_desc</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AD100</td>\n",
+       "      <td>ALCOHOL DETERRENTS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AD200</td>\n",
+       "      <td>CYANIDE ANTIDOTES</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AD300</td>\n",
+       "      <td>HEAVY METAL ANTAGONISTS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AD400</td>\n",
+       "      <td>ANTIDOTES,DETERRENTS,AND POISON CONTROL EXCHAN...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  drug_class                                    drug_class_desc\n",
+       "0          0                                    UNKNOWN/MISSING\n",
+       "1      AD100                                 ALCOHOL DETERRENTS\n",
+       "2      AD200                                  CYANIDE ANTIDOTES\n",
+       "3      AD300                            HEAVY METAL ANTAGONISTS\n",
+       "4      AD400  ANTIDOTES,DETERRENTS,AND POISON CONTROL EXCHAN..."
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_class.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "drug_class.replace(to_replace=np.nan, value=\"N/A\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Okay, cool, I think that's all the information I need!\n",
+    "\n",
+    "## Adding Drug classes to the Drug information Table\n",
+    "\n",
+    "We can now use the available information to add a column `drug_major_class` and `drug_class` to the `drugnames` table for use in identification and visualization.\n",
+    "\n",
+    "To revise, I have four tables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drugname_brand</th>\n",
+       "      <th>drugname_generic</th>\n",
+       "      <th>RXCUI</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10 wash</td>\n",
+       "      <td>sulfacetamide sodium</td>\n",
+       "      <td>10169</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1st tier unifine pentips</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1st tier unifine pentips plus</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>60pse-400gfn-20dm</td>\n",
+       "      <td>guaifenesin/dm/pseudoephedrine</td>\n",
+       "      <td>5032|8896</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8-mop</td>\n",
+       "      <td>methoxsalen</td>\n",
+       "      <td>6854|227713</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  drugname_brand                drugname_generic        RXCUI\n",
+       "0                        10 wash            sulfacetamide sodium        10169\n",
+       "1       1st tier unifine pentips            pen needle, diabetic            0\n",
+       "2  1st tier unifine pentips plus            pen needle, diabetic            0\n",
+       "3              60pse-400gfn-20dm  guaifenesin/dm/pseudoephedrine    5032|8896\n",
+       "4                          8-mop                     methoxsalen  6854|227713"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drugnames.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the brand names, the generic names and the RxNorm identifier of the drug. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RXNORM_RXCUI</th>\n",
+       "      <th>DRUG_MAJOR_CLASS</th>\n",
+       "      <th>DRUG_CLASS</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   RXNORM_RXCUI DRUG_MAJOR_CLASS DRUG_CLASS\n",
+       "0             0                0          0\n",
+       "1             0                0          0\n",
+       "2             0                0          0\n",
+       "3             0                0          0\n",
+       "4             0                0          0"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "with the RxNorm values as well as major/minor classes of the drug. \n",
+    "\n",
+    "And finally, "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drug_major_class</th>\n",
+       "      <th>drug_major_class_desc</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AD000</td>\n",
+       "      <td>ANTIDOTES,DETERRENTS AND POISON CONTROL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AH000</td>\n",
+       "      <td>ANTIHISTAMINES</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AM000</td>\n",
+       "      <td>ANTIMICROBIALS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AN000</td>\n",
+       "      <td>ANTINEOPLASTICS</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  drug_major_class                    drug_major_class_desc\n",
+       "0                0                          UNKNOWN/MISSING\n",
+       "1            AD000  ANTIDOTES,DETERRENTS AND POISON CONTROL\n",
+       "2            AH000                           ANTIHISTAMINES\n",
+       "3            AM000                           ANTIMICROBIALS\n",
+       "4            AN000                          ANTINEOPLASTICS"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_major_class.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drug_class</th>\n",
+       "      <th>drug_class_desc</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AD100</td>\n",
+       "      <td>ALCOHOL DETERRENTS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AD200</td>\n",
+       "      <td>CYANIDE ANTIDOTES</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AD300</td>\n",
+       "      <td>HEAVY METAL ANTAGONISTS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AD400</td>\n",
+       "      <td>ANTIDOTES,DETERRENTS,AND POISON CONTROL EXCHAN...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  drug_class                                    drug_class_desc\n",
+       "0          0                                    UNKNOWN/MISSING\n",
+       "1      AD100                                 ALCOHOL DETERRENTS\n",
+       "2      AD200                                  CYANIDE ANTIDOTES\n",
+       "3      AD300                            HEAVY METAL ANTAGONISTS\n",
+       "4      AD400  ANTIDOTES,DETERRENTS,AND POISON CONTROL EXCHAN..."
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drug_class.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "have the identifiers for the major and minor drug classes.\n",
+    "\n",
+    "I'm going to add four columns to `drugnames`, one for each major and minor drug class, and one for the string representations of those classes, which will make the table bigger, but easier to use in the long term."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "drugnames[\"drug_major_class\"] = \"\"\n",
+    "drugnames[\"dmc_string\"] = \"\"\n",
+    "drugnames[\"drug_class\"] = \"\"\n",
+    "drugnames[\"dc_string\"] = \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It looks like there are a bunch of drug classes that don't match between the drug classes in the key and the drug classes in the table. Because of course there are. \n",
+    "**For now, any drug class we don't have an explanation for will be considered missing!**\n",
+    "\n",
+    "How many are those?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "drugnames[\"RXCUI\"] = drugnames[\"RXCUI\"].astype(str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for idx in drugnames.index:\n",
+    "\n",
+    "    drug_rxcui = drugnames.loc[idx, \"RXCUI\"].split(\"|\")\n",
+    "    dmc, dc = [], []\n",
+    "    for rxcui in drug_rxcui:\n",
+    "        #print(df[df[\"RXNORM_RXCUI\"] == np.float(rxcui)])\n",
+    "        r = df[df[\"RXNORM_RXCUI\"] == np.float(rxcui)]\n",
+    "\n",
+    "        rxc = r.loc[r.index, \"RXNORM_RXCUI\"].unique()\n",
+    "\n",
+    "        dmc.extend(r.loc[r.index, \"DRUG_MAJOR_CLASS\"].unique())\n",
+    "        dc.extend(r.loc[r.index, \"DRUG_CLASS\"].unique())\n",
+    "\n",
+    "\n",
+    "    dmc = np.unique(dmc)\n",
+    "    dc = np.unique(dc)\n",
+    "\n",
+    "    if len(dmc) != 0:\n",
+    "        drugnames.loc[idx, \"drug_major_class\"] = \"|\".join(dmc)\n",
+    "        dmc_name = np.hstack([drug_major_class.loc[drug_major_class[\"drug_major_class\"] == d, \"drug_major_class_desc\"].values for d in dmc])\n",
+    "        drugnames.loc[idx, \"dmc_name\"] = \"|\".join(dmc_name)\n",
+    "\n",
+    "    else:\n",
+    "        drugnames.loc[idx, \"drug_major_class\"] = \"0\"\n",
+    "        drugnames.loc[idx, \"dmc_name\"] = \"0\"\n",
+    "\n",
+    "    if len(dc) != 0:\n",
+    "        drugnames.loc[idx, \"drug_class\"] = \"|\".join(dc)\n",
+    "        dc_name = np.hstack([drug_class.loc[drug_class[\"drug_class\"] == d, \"drug_class_desc\"].values for d in dc])        \n",
+    "        drugnames.loc[idx, \"dc_name\"] = \"|\".join(dc_name)\n",
+    "    else:\n",
+    "        drugnames.loc[idx, \"drug_class\"] = \"0\"\n",
+    "        drugnames.loc[idx, \"dc_name\"] = \"0\"\n",
+    "\n",
+    "        \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>drugname_brand</th>\n",
+       "      <th>drugname_generic</th>\n",
+       "      <th>RXCUI</th>\n",
+       "      <th>drug_major_class</th>\n",
+       "      <th>dmc_string</th>\n",
+       "      <th>drug_class</th>\n",
+       "      <th>dc_string</th>\n",
+       "      <th>dmc_name</th>\n",
+       "      <th>dc_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10 wash</td>\n",
+       "      <td>sulfacetamide sodium</td>\n",
+       "      <td>10169</td>\n",
+       "      <td>0|DE000|OP000</td>\n",
+       "      <td></td>\n",
+       "      <td>0|DE101|OP210</td>\n",
+       "      <td></td>\n",
+       "      <td>UNKNOWN/MISSING|DERMATOLOGICAL AGENTS|OPHTHALM...</td>\n",
+       "      <td>UNKNOWN/MISSING|ANTI-INFECTIVE,TOPICAL|ANTI-IN...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1st tier unifine pentips</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td></td>\n",
+       "      <td>0</td>\n",
+       "      <td></td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1st tier unifine pentips plus</td>\n",
+       "      <td>pen needle, diabetic</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td></td>\n",
+       "      <td>0</td>\n",
+       "      <td></td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "      <td>UNKNOWN/MISSING</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>60pse-400gfn-20dm</td>\n",
+       "      <td>guaifenesin/dm/pseudoephedrine</td>\n",
+       "      <td>5032|8896</td>\n",
+       "      <td>RE000</td>\n",
+       "      <td></td>\n",
+       "      <td>RE200|RE302</td>\n",
+       "      <td></td>\n",
+       "      <td>RESPIRATORY TRACT MEDICATIONS</td>\n",
+       "      <td>DECONGESTANTS,SYSTEMIC|ANTITUSSIVES/EXPECTORANTS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8-mop</td>\n",
+       "      <td>methoxsalen</td>\n",
+       "      <td>6854|227713</td>\n",
+       "      <td>DE000</td>\n",
+       "      <td></td>\n",
+       "      <td>DE810</td>\n",
+       "      <td></td>\n",
+       "      <td>DERMATOLOGICAL AGENTS</td>\n",
+       "      <td>ANTIPSORIATIC</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  drugname_brand                drugname_generic        RXCUI  \\\n",
+       "0                        10 wash            sulfacetamide sodium        10169   \n",
+       "1       1st tier unifine pentips            pen needle, diabetic          0.0   \n",
+       "2  1st tier unifine pentips plus            pen needle, diabetic          0.0   \n",
+       "3              60pse-400gfn-20dm  guaifenesin/dm/pseudoephedrine    5032|8896   \n",
+       "4                          8-mop                     methoxsalen  6854|227713   \n",
+       "\n",
+       "  drug_major_class dmc_string     drug_class dc_string  \\\n",
+       "0    0|DE000|OP000             0|DE101|OP210             \n",
+       "1                0                         0             \n",
+       "2                0                         0             \n",
+       "3            RE000               RE200|RE302             \n",
+       "4            DE000                     DE810             \n",
+       "\n",
+       "                                            dmc_name  \\\n",
+       "0  UNKNOWN/MISSING|DERMATOLOGICAL AGENTS|OPHTHALM...   \n",
+       "1                                    UNKNOWN/MISSING   \n",
+       "2                                    UNKNOWN/MISSING   \n",
+       "3                      RESPIRATORY TRACT MEDICATIONS   \n",
+       "4                              DERMATOLOGICAL AGENTS   \n",
+       "\n",
+       "                                             dc_name  \n",
+       "0  UNKNOWN/MISSING|ANTI-INFECTIVE,TOPICAL|ANTI-IN...  \n",
+       "1                                    UNKNOWN/MISSING  \n",
+       "2                                    UNKNOWN/MISSING  \n",
+       "3   DECONGESTANTS,SYSTEMIC|ANTITUSSIVES/EXPECTORANTS  \n",
+       "4                                      ANTIPSORIATIC  "
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drugnames.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Serialize drug names to feather file for use in both Python and R\n",
+    "import feather\n",
+    "feather.write_dataframe(drugnames, data_dir + 'drugnames_withclasses.feather')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/cms/druguse_definitions.ipynb
+++ b/cms/druguse_definitions.ipynb
@@ -34,7 +34,13 @@
     "import os # rename file to something more type-able\n",
     "import numpy as np\n",
     "\n",
-    "data_dir = '../data/'\n",
+    "data_dir = \"../data/\"\n",
+    "\n",
+    "try:\n",
+    "    os.stat(data_dir)\n",
+    "except FileNotFoundError:\n",
+    "    os.mkdir(data_dir)\n",
+    "    \n",
     "url = \"https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/BSAPUFS/Downloads/2010_PD_Profiles_PUF.zip\"\n",
     "response = requests.get(url, stream=True)\n",
     "\n",
@@ -72,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "df = pd.read_csv(\"../data/2010_PD_Profiles_PUF.csv\")"
+    "puf = pd.read_csv(\"../data/2010_PD_Profiles_PUF.csv\")"
    ]
   },
   {
@@ -90,11 +96,11 @@
    },
    "outputs": [],
    "source": [
-    "df.drop(\"BENE_SEX_IDENT_CD\", axis=1, inplace=True)\n",
-    "df.drop(\"BENE_AGE_CAT_CD\", axis=1, inplace=True)\n",
-    "df.drop(\"PDE_DRUG_TYPE_CD\", axis=1, inplace=True)\n",
-    "df.drop(\"PLAN_TYPE\", axis=1, inplace=True)\n",
-    "df.drop([\"COVERAGE_TYPE\", \"benefit_phase\",\"DRUG_BENEFIT_TYPE\",\n",
+    "puf.drop(\"BENE_SEX_IDENT_CD\", axis=1, inplace=True)\n",
+    "puf.drop(\"BENE_AGE_CAT_CD\", axis=1, inplace=True)\n",
+    "puf.drop(\"PDE_DRUG_TYPE_CD\", axis=1, inplace=True)\n",
+    "puf.drop(\"PLAN_TYPE\", axis=1, inplace=True)\n",
+    "puf.drop([\"COVERAGE_TYPE\", \"benefit_phase\",\"DRUG_BENEFIT_TYPE\",\n",
     "         \"PRESCRIBER_TYPE\", \"GAP_COVERAGE\", \"TIER_ID\", \"MEAN_RXHCC_SCORE\",\n",
     "         \"AVE_DAYS_SUPPLY\", \"AVE_TOT_DRUG_COST\", \"AVE_PTNT_PAY_AMT\",\n",
     "         \"PDE_CNT\", \"BENE_CNT_CAT\"], axis=1, inplace=True)"
@@ -109,59 +115,8 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>RXNORM_RXCUI</th>\n",
-       "      <th>DRUG_MAJOR_CLASS</th>\n",
-       "      <th>DRUG_CLASS</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "   RXNORM_RXCUI DRUG_MAJOR_CLASS DRUG_CLASS\n",
-       "0             0                0          0\n",
-       "1             0                0          0\n",
-       "2             0                0          0\n",
-       "3             0                0          0\n",
-       "4             0                0          0"
+       "1229"
       ]
      },
      "execution_count": 5,
@@ -170,29 +125,7 @@
     }
    ],
    "source": [
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1229"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(df[\"RXNORM_RXCUI\"].unique())"
+    "len(puf[\"RXNORM_RXCUI\"].unique())"
    ]
   },
   {
@@ -208,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -221,7 +154,11 @@
     "with open(data_dir + 'rxnorm_dataset.zip', 'wb') as ds_zipout:\n",
     "    shutil.copyfileobj(response.raw, ds_zipout)\n",
     "\n",
-    "os.makedirs(data_dir+\"rxnorm/\")\n",
+    "try:\n",
+    "    os.stat(data_dir+\"rxnorm/\")\n",
+    "except FileNotFoundError:\n",
+    "    os.mkdir(data_dir+\"rxnorm/\")\n",
+    "    \n",
     "zip = zipfile.ZipFile(data_dir + 'rxnorm_dataset.zip', 'r')\n",
     "\n",
     "ds_filenames = zip.namelist()\n",
@@ -258,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -273,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -329,7 +266,7 @@
        "4     73  Docosahexaenoate"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -372,7 +309,7 @@
        "30703  228476  GATIFLOXACIN"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -408,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -420,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -476,7 +413,7 @@
        "4                          8-MOP                     METHOXSALEN"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -496,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "collapsed": true
    },
@@ -508,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -564,7 +501,7 @@
        "4                          8-mop                     methoxsalen"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -582,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {
     "collapsed": true
    },
@@ -600,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -608,30 +545,21 @@
    "source": [
     "for idx in drugnames.index:\n",
     "\n",
-    "    d = drugnames.loc[idx, \"drugname_generic\"]\n",
-    "    dsplit = d.split(\"/\")\n",
-    "\n",
     "    rxcui = []\n",
-    "    for di in dsplit:\n",
-    "        displit = di.split(\" \")\n",
-    "        v = rxnorm[rxnorm[\"STR\"] == displit[0]]\n",
     "\n",
-    "        if len(v) > 0:\n",
-    "            rxcui.extend(v[\"RXCUI\"].unique())\n",
-    "        else:\n",
-    "            continue\n",
+    "    for c in [\"drugname_generic\", \"drugname_brand\"]:\n",
+    "        \n",
+    "        d = drugnames.loc[idx, c]\n",
+    "        dsplit = d.split(\"/\")\n",
     "\n",
-    "    d = drugnames.loc[idx, \"drugname_brand\"]\n",
-    "    dsplit = d.split(\" \")\n",
-    "    \n",
-    "    for di in dsplit:\n",
-    "        displit = di.split(\" \")\n",
-    "        v = rxnorm[rxnorm[\"STR\"] == displit[0]]\n",
+    "        for di in dsplit:\n",
+    "            displit = di.split(\" \")\n",
+    "            v = rxnorm[rxnorm[\"STR\"] == displit[0]]\n",
     "\n",
-    "        if len(v) > 0:\n",
-    "            rxcui.extend(v[\"RXCUI\"].unique())\n",
-    "        else:\n",
-    "            continue\n",
+    "            if len(v) > 0:\n",
+    "                rxcui.extend(v[\"RXCUI\"].unique())\n",
+    "            else:\n",
+    "                continue\n",
     "\n",
     "    if len(rxcui) > 1:\n",
     "        rxcui_str = \"|\".join(np.array(rxcui, dtype=str))\n",
@@ -642,7 +570,6 @@
     "        rxcui_str = 0.0\n",
     "    \n",
     "    drugnames.loc[idx, \"RXCUI\"] = rxcui_str\n",
-    "\n",
     "\n"
    ]
   },
@@ -655,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -663,10 +590,10 @@
     {
      "data": {
       "text/plain": [
-       "620"
+       "634"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -684,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -692,10 +619,10 @@
     {
      "data": {
       "text/plain": [
-       "0.1378390395731436"
+       "0.14095153401511784"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -713,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -775,7 +702,7 @@
        "26  acetaminoph-caff-dihydrocodein  dhcodeine bt/acetaminophn/caff     0"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -798,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -819,7 +746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -830,7 +757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -886,7 +813,7 @@
        "4            AN000                          ANTINEOPLASTICS"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -897,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },
@@ -908,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -964,7 +891,7 @@
        "4      AD400  ANTIDOTES,DETERRENTS,AND POISON CONTROL EXCHAN..."
       ]
      },
-     "execution_count": 25,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -975,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -999,7 +926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -1061,7 +988,7 @@
        "4                          8-mop                     methoxsalen  6854|227713"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1079,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -1141,13 +1068,13 @@
        "4             0                0          0"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.head()"
+    "puf.head()"
    ]
   },
   {
@@ -1161,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -1217,7 +1144,7 @@
        "4            AN000                          ANTINEOPLASTICS"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1235,7 +1162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -1291,7 +1218,7 @@
        "4      AD400  ANTIDOTES,DETERRENTS,AND POISON CONTROL EXCHAN..."
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1311,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {
     "collapsed": true
    },
@@ -1335,7 +1262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -1346,7 +1273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
@@ -1357,8 +1284,7 @@
     "    drug_rxcui = drugnames.loc[idx, \"RXCUI\"].split(\"|\")\n",
     "    dmc, dc = [], []\n",
     "    for rxcui in drug_rxcui:\n",
-    "        #print(df[df[\"RXNORM_RXCUI\"] == np.float(rxcui)])\n",
-    "        r = df[df[\"RXNORM_RXCUI\"] == np.float(rxcui)]\n",
+    "        r = puf[puf[\"RXNORM_RXCUI\"] == np.float(rxcui)]\n",
     "\n",
     "        rxc = r.loc[r.index, \"RXNORM_RXCUI\"].unique()\n",
     "\n",
@@ -1371,7 +1297,8 @@
     "\n",
     "    if len(dmc) != 0:\n",
     "        drugnames.loc[idx, \"drug_major_class\"] = \"|\".join(dmc)\n",
-    "        dmc_name = np.hstack([drug_major_class.loc[drug_major_class[\"drug_major_class\"] == d, \"drug_major_class_desc\"].values for d in dmc])\n",
+    "        dmc_name = np.hstack([drug_major_class.loc[drug_major_class[\"drug_major_class\"] == d, \n",
+    "                                                   \"drug_major_class_desc\"].values for d in dmc])\n",
     "        drugnames.loc[idx, \"dmc_name\"] = \"|\".join(dmc_name)\n",
     "\n",
     "    else:\n",
@@ -1380,19 +1307,18 @@
     "\n",
     "    if len(dc) != 0:\n",
     "        drugnames.loc[idx, \"drug_class\"] = \"|\".join(dc)\n",
-    "        dc_name = np.hstack([drug_class.loc[drug_class[\"drug_class\"] == d, \"drug_class_desc\"].values for d in dc])        \n",
+    "        dc_name = np.hstack([drug_class.loc[drug_class[\"drug_class\"] == d, \n",
+    "                                            \"drug_class_desc\"].values for d in dc])   \n",
+    "\n",
     "        drugnames.loc[idx, \"dc_name\"] = \"|\".join(dc_name)\n",
     "    else:\n",
     "        drugnames.loc[idx, \"drug_class\"] = \"0\"\n",
-    "        drugnames.loc[idx, \"dc_name\"] = \"0\"\n",
-    "\n",
-    "        \n",
-    "\n"
+    "        drugnames.loc[idx, \"dc_name\"] = \"0\"\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false
    },
@@ -1511,7 +1437,7 @@
        "4                                      ANTIPSORIATIC  "
       ]
      },
-     "execution_count": 34,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1522,7 +1448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {
     "collapsed": true
    },


### PR DESCRIPTION
While exploring the data for issue #15, I realized quickly that we actually need to be able to sort the drugs into categories. After a bit of reading, I found the CMS [prescription drug profiles](https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/BSAPUFS/Prescription_Drug_Profiles.html) useful, in particular because they use a categorization from the Veteran's Affairs National Drug File. The latter classifies drugs by effect, both broadly and more finely, so that should do well for a first attempt at showing different drug uses. 

This notebook describes the data sources, download and cleaning I went through to get an extended version of the `drugnames.feather` file described in [this notebook](http://localhost:8888/notebooks/repositories/d4d/drug-spending/cms/part-d_convert_to_feather.ipynb). The new file includes columns for drug use classes, and can now be used for visualization. 

There are a few hacks in there that we might want to deal with more cleanly in the long run, but I don't have a good enough understanding yet for the data to do that.

Comments and suggestions welcome. :)