### PR TITLE
Merck generic to brand name mapping

### DIFF
--- a/merck_gen_brnd_tbl_clean.py
+++ b/merck_gen_brnd_tbl_clean.py
@@ -30,6 +30,10 @@ url = chrome.page_source
 # do some magic
 soup = BeautifulSoup(url)
 
+
+
+##### Base xref table scraping #####
+
 # find start of table
 table_start = soup.find(class_="drugDrugTitleTrade drug-table")
 # get list of drug names from table body
@@ -52,3 +56,8 @@ def initcap(text):
 df = pd.DataFrame(data).apply(initcap)
 
 df.to_csv('/Users/Travis/Downloads/merck_gen_brnd_table_scrape.csv',header=True,index=False,sep='|')
+
+
+#####################################
+
+##### Generic drug pop up scraping #####

--- a/merck_gen_brnd_tbl_clean.py
+++ b/merck_gen_brnd_tbl_clean.py
@@ -1,5 +1,9 @@
 from selenium import webdriver
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 import time
 from bs4 import BeautifulSoup
 import pandas as pd
@@ -61,3 +65,8 @@ df.to_csv('/Users/Travis/Downloads/merck_gen_brnd_table_scrape.csv',header=True,
 #####################################
 
 ##### Generic drug pop up scraping #####
+
+chrome.find_element_by_xpath("//tbody/tr/td").click()
+
+for i in WebDriverWait(chrome, 6).until(EC.visibility_of_element_located((By.CLASS_NAME, 'lexi-main'))).find_elements_by_xpath("//p"):
+    print(i.text)

--- a/merck_gen_brnd_tbl_clean.py
+++ b/merck_gen_brnd_tbl_clean.py
@@ -8,6 +8,7 @@ import pandas as pd
 ## runs in python 3.5
 ## need to download the chromium webdriver
 ## reference the location of the executable
+## https://sites.google.com/a/chromium.org/chromedriver/
 path_to_chromedriver = '/Users/Travis/chromedriver'
 chrome = webdriver.Chrome(path_to_chromedriver)
 ## set windows size so it doesn't open in mobile version of set

--- a/merck_gen_brnd_tbl_clean.py
+++ b/merck_gen_brnd_tbl_clean.py
@@ -1,0 +1,46 @@
+from bs4 import BeautifulSoup
+import pandas as pd
+
+
+## downloaded from http://www.merckmanuals.com/professional/appendixes/brand-names-of-some-commonly-used-drugs
+url = '~/Downloads/merck_gen_brnd_drug_nms.html'
+
+
+# strip tags
+with open(url,'rb') as f:
+    soup = BeautifulSoup(f)
+    
+text = soup.get_text()
+
+# find block of text where drug names are stored
+
+def find_drug_text(string,keyword):
+    cleaned_temp = []
+    beg_table = string[string.find(keyword)+11:]
+    all_drugs = beg_table[:beg_table.find(keyword)]
+    temp = all_drugs.split('\n')
+    
+    for i in temp:
+        if i != '':
+            cleaned_temp.append(i)
+    return cleaned_temp
+
+# parse the list into generic and brand key values
+def parse_text(somelist):
+    lod = []
+    for index, name in enumerate(somelist):
+        if index == 0 or index % 2 == 0:
+            generic = name
+        else:
+            brand = name
+            lod.append({'Generic':generic,'Brand':brand})
+    return lod
+    
+# write to csv
+cleaned_file = parse_text(find_drug_text(text,'BRAND NAMES'))
+pd.DataFrame(cleaned_file).to_csv('~/Downloads/merck_gen_brnd_table_scrape.csv',index=False,header=True,sep='|')
+
+        
+
+
+    

--- a/merck_gen_brnd_tbl_clean.py
+++ b/merck_gen_brnd_tbl_clean.py
@@ -8,7 +8,6 @@ import time
 from bs4 import BeautifulSoup
 import pandas as pd
 
-
 ## runs in python 3.5
 ## need to download the chromium webdriver
 ## reference the location of the executable
@@ -67,6 +66,15 @@ df.to_csv('/Users/Travis/Downloads/merck_gen_brnd_table_scrape.csv',header=True,
 ##### Generic drug pop up scraping #####
 
 chrome.find_element_by_xpath("//tbody/tr/td").click()
+drug_detail = []
+#for i in WebDriverWait(chrome, 6).until(EC.visibility_of_element_located((By.CLASS_NAME, 'lexi-main'))).find_elements_by_xpath("//p"):
 
-for i in WebDriverWait(chrome, 6).until(EC.visibility_of_element_located((By.CLASS_NAME, 'lexi-main'))).find_elements_by_xpath("//p"):
-    print(i.text)
+popup = WebDriverWait(chrome, 6).until(EC.visibility_of_element_located((By.CLASS_NAME, 'lexi-main')))
+
+## items to gather:
+# brand names: US, brand names: Canada, Pharmacologic Category, How to break out and format the dosing information, Calculations,
+
+for p in popup.find_elements_by_xpath("//div"):
+    drug_detail.append(p.text)
+
+drug_detail

--- a/merck_gen_brnd_tbl_clean.py
+++ b/merck_gen_brnd_tbl_clean.py
@@ -1,15 +1,34 @@
+from selenium import webdriver
+from selenium.webdriver.common.action_chains import ActionChains
+import time
 from bs4 import BeautifulSoup
 import pandas as pd
 
 
-## downloaded from http://www.merckmanuals.com/professional/appendixes/brand-names-of-some-commonly-used-drugs
-url = '~/Downloads/merck_gen_brnd_drug_nms.html'
+## runs in python 3.5
+## need to download the chromium webdriver
+## reference the location of the executable
+path_to_chromedriver = '/Users/Travis/chromedriver'
+chrome = webdriver.Chrome(path_to_chromedriver)
+## set windows size so it doesn't open in mobile version of set
+# if opens in mobile site then you need to search for a different set of attributes
+chrome.set_window_size(1600, 1600)
+## the root site
+chrome.get('http://www.merckmanuals.com/professional')
+## drug name link doesn't become active until you hover over the menu.  This is the class to hover over
+element_to_hover_over = chrome.find_element_by_xpath("//li[@class='item2 itemEdge main-menu-item leftSide ']")
+## Perform the hover to expose the link
+ActionChains(chrome).move_to_element(element_to_hover_over).perform()
+## without the sleep you don't see the link, it loads too slow for the script
+time.sleep(4)
+## click on the link, find it by link name in the span tag
+chrome.find_element_by_link_text('Drugs by Name, Generic and Brand').click()
 
+# get the html of the current page
+url = chrome.page_source
+# do some magic
+soup = BeautifulSoup(url)
 
-# strip tags
-with open(url,'rb') as f:
-    soup = BeautifulSoup(f)
-    
 text = soup.get_text()
 
 # find block of text where drug names are stored
@@ -19,7 +38,7 @@ def find_drug_text(string,keyword):
     beg_table = string[string.find(keyword)+11:]
     all_drugs = beg_table[:beg_table.find(keyword)]
     temp = all_drugs.split('\n')
-    
+
     for i in temp:
         if i != '':
             cleaned_temp.append(i)
@@ -35,12 +54,7 @@ def parse_text(somelist):
             brand = name
             lod.append({'Generic':generic,'Brand':brand})
     return lod
-    
+
 # write to csv
 cleaned_file = parse_text(find_drug_text(text,'BRAND NAMES'))
-pd.DataFrame(cleaned_file).to_csv('~/Downloads/merck_gen_brnd_table_scrape.csv',index=False,header=True,sep='|')
-
-        
-
-
-    
+pd.DataFrame(cleaned_file).to_csv('/Users/Travis/Downloads/merck_gen_brnd_table_scrape.csv',index=False,header=True,sep='|')


### PR DESCRIPTION
Python script to navigate the Merck professional site.  This parses the landing page with the table for the xref between generic and brand name drugs